### PR TITLE
Allow cacheKey to accept arbitrary options objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "lint": "eslint src",
     "build": "babel src -d lib",
     "test": "docker-compose run --rm dev npm run test:raw",
-    "test:raw": "npm run lint && NODE_ENV=test mocha $npm_package_options_mocha 'test/**.test.js'"
+    "test:raw": "npm run lint && npm run test:unit && npm run test:integration",
+    "test:unit": "NODE_ENV=test mocha $npm_package_options_mocha 'test/unit/**.test.js'",
+    "test:integration": "NODE_ENV=test mocha $npm_package_options_mocha 'test/integration/**.test.js'"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",

--- a/src/index.js
+++ b/src/index.js
@@ -38,13 +38,22 @@ function mapResult(attribute, keys, options, result) {
   });
 }
 
-function getCacheKey(model, attribute, options) {
-  return model.name + attribute + JSON.stringify(options, (key, value) => {
+export function getCacheKey(model, attribute, options) {
+  return model.name + attribute + JSON.stringify(options, function replacer(key, value) {
+    if (!key) {
+      // We were called with the whole object
+      return value;
+    }
+
     if (key === 'association') {
       return value.associationType + value.target.name + value.as;
     }
 
-    return value;
+    if (['attributes', 'limit', 'groupedLimit', 'order'].indexOf(key) !== -1) {
+      return value;
+    }
+
+    return undefined; // skip
   });
 }
 

--- a/test/integration/belongsTo.test.js
+++ b/test/integration/belongsTo.test.js
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
-import {connection, randint} from './helper';
+import {connection, randint} from '../helper';
 import sinon from 'sinon';
-import dataloaderSequelize from '../src';
+import dataloaderSequelize from '../../src';
 import Promise from 'bluebird';
 import expect from 'unexpected';
 

--- a/test/integration/belongsToMany.test.js
+++ b/test/integration/belongsToMany.test.js
@@ -1,6 +1,6 @@
-import {connection, randint} from './helper';
+import {connection, randint} from '../helper';
 import sinon from 'sinon';
-import dataloaderSequelize from '../src';
+import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 import Sequelize from 'sequelize';
 

--- a/test/integration/findById.test.js
+++ b/test/integration/findById.test.js
@@ -1,7 +1,7 @@
 import Sequelize from 'sequelize';
-import {connection, randint} from './helper';
+import {connection, randint} from '../helper';
 import sinon from 'sinon';
-import dataloaderSequelize from '../src';
+import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 
 describe('findById', function () {

--- a/test/integration/hasMany.test.js
+++ b/test/integration/hasMany.test.js
@@ -1,6 +1,6 @@
-import {connection, randint} from './helper';
+import {connection, randint} from '../helper';
 import sinon from 'sinon';
-import dataloaderSequelize from '../src';
+import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 
 describe('hasMany', function () {

--- a/test/integration/hasOne.test.js
+++ b/test/integration/hasOne.test.js
@@ -1,6 +1,6 @@
-import {connection, randint} from './helper';
+import {connection, randint} from '../helper';
 import sinon from 'sinon';
-import dataloaderSequelize from '../src';
+import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 import Promise from 'bluebird';
 

--- a/test/unit/getCacheKey.test.js
+++ b/test/unit/getCacheKey.test.js
@@ -1,0 +1,34 @@
+import {getCacheKey} from '../../src';
+import expect from 'unexpected';
+import {connection} from '../helper';
+
+describe('getCacheKey', function () {
+  it('handles circular structures', function () {
+    let foo = {}
+      , bar = {}
+      , options = {
+        foo,
+        bar
+      };
+
+    foo.bar = bar;
+    bar.foo = foo;
+
+    expect(getCacheKey({
+      name: 'user'
+    }, 'id', options), 'to equal', 'userid{}');
+  });
+
+  it('handles associations', function () {
+    let User = connection.define('user')
+      , Task = connection.define('task')
+      , association = User.hasMany(Task)
+      , options = {
+        association,
+        limit: 42
+      };
+
+    expect(getCacheKey(User, 'id', options), 'to equal', 'userid{"association":"HasManytasktasks","limit":42}');
+  });
+});
+

--- a/test/unit/shimming.test.js
+++ b/test/unit/shimming.test.js
@@ -1,5 +1,5 @@
-import {connection} from './helper';
-import dataloaderSequelize from '../src';
+import {connection} from '../helper';
+import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 
 describe('shimming', function () {


### PR DESCRIPTION
`graphql-sequelize` passes `context` and `root` objects in options, which caused problems because we tried to `JSON.stringify` as circular structure. Now we only stringify what we need to 