### PR TITLE
Small fixes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -236,6 +236,7 @@
     ],
     "wrap-regex": 0,
     "no-var": 0,
-    "max-len": [2, 200, 4]
+    "max-len": [2, 200, 4],
+    "no-restricted-globals": [2, "Promise"]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ function mapResult(attribute, keys, options, result) {
         carry[key].push(row);
       }
 
-
       return carry;
     }, {});
   } else {
@@ -152,6 +151,9 @@ function loaderForModel(model, attribute, options = {}) {
 function shimModel(target) {
   shimmer.massWrap(target, ['findById', 'findByPrimary'], original => {
     return function batchedFindById(id, options = {}) {
+      if ([null, undefined].indexOf(id) !== -1) {
+        return Promise.resolve(null);
+      }
       if (options.transaction) {
         return original.apply(this, arguments);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,8 @@ function loaderForModel(model, attribute, options = {}) {
 }
 
 function shimModel(target) {
+  if (target.findById.__wrapped) return;
+
   shimmer.massWrap(target, ['findById', 'findByPrimary'], original => {
     return function batchedFindById(id, options = {}) {
       if ([null, undefined].indexOf(id) !== -1) {
@@ -163,6 +165,8 @@ function shimModel(target) {
 }
 
 function shimBelongsTo(target) {
+  if (target.get.__wrapped) return;
+
   shimmer.wrap(target, 'get', original => {
     return function batchedGetBelongsTo(instance, options = {}) {
       // targetKeyIsPrimary already handled by sequelize (maps to findById)
@@ -177,6 +181,8 @@ function shimBelongsTo(target) {
 }
 
 function shimHasOne(target) {
+  if (target.get.__wrapped) return;
+
   shimmer.wrap(target, 'get', original => {
     return function batchedGetHasOne(instance, options = {}) {
       if (Array.isArray(instance) || options.include || options.transaction) {
@@ -190,6 +196,8 @@ function shimHasOne(target) {
 }
 
 function shimHasMany(target) {
+  if (target.get.__wrapped) return;
+
   shimmer.wrap(target, 'get', original => {
     return function bathedGetHasMany(instances, options = {}) {
       if (options.include || options.transaction) {
@@ -211,6 +219,8 @@ function shimHasMany(target) {
 }
 
 function shimBelongsToMany(target) {
+  if (target.get.__wrapped) return;
+
   shimmer.wrap(target, 'get', original => {
     return function bathedGetHasMany(instances, options = {}) {
       assert(this.paired, '.paired missing on belongsToMany association. You need to set up both sides of the association');

--- a/test/integration/belongsToMany.test.js
+++ b/test/integration/belongsToMany.test.js
@@ -12,149 +12,162 @@ describe('belongsToMany', function () {
     this.sandbox.restore();
   });
 
-  describe('simple association', function () {
-    beforeEach(async function () {
-      this.sandbox = sinon.sandbox.create();
+  [
+    ['string through', context => {
+      context.Project.Users = context.Project.belongsToMany(context.User, { as: 'members', through: 'project_members' });
+      context.User.belongsToMany(context.Project, { through: 'project_members' });
+    }],
+    ['model through', context => {
+      context.ProjectMembers = connection.define('project_members');
+      context.Project.Users = context.Project.belongsToMany(context.User, { as: 'members', through: context.ProjectMembers });
+      context.User.belongsToMany(context.Project, { through: context.ProjectMembers });
+    }]
+  ].forEach(([description, setup]) => {
+    describe(description, function () {
+      describe('simple association', function () {
+        beforeEach(async function () {
+          this.sandbox = sinon.sandbox.create();
 
-      this.User = connection.define('user', {
-        name: Sequelize.STRING,
-        awesome: Sequelize.BOOLEAN
+          this.User = connection.define('user', {
+            name: Sequelize.STRING,
+            awesome: Sequelize.BOOLEAN
+          });
+          this.Project = connection.define('project');
+
+          setup(this);
+
+          await connection.sync({
+            force: true
+          });
+
+          [this.project1, this.project2, this.project3] = await this.Project.bulkCreate([
+            { id: randint() },
+            { id: randint() },
+            { id: randint() }
+          ], {returning: true});
+          this.users = await this.User.bulkCreate([
+            { id: randint(), awesome: false},
+            { id: randint(), awesome: true },
+            { id: randint(), awesome: true },
+            { id: randint(), awesome: false },
+            { id: randint(), awesome: true },
+            { id: randint(), awesome: false },
+            { id: randint(), awesome: true },
+            { id: randint(), awesome: true },
+            { id: randint(), awesome: true }
+          ], {returning: true});
+
+          await this.project1.setMembers(this.users.slice(0, 4));
+          await this.project2.setMembers(this.users.slice(3, 7));
+          await this.project3.setMembers(this.users.slice(6));
+
+          dataloaderSequelize(this.Project);
+          this.sandbox.spy(this.User, 'findAll');
+        });
+
+        it('batches to a single findAll call', async function () {
+          let members1 = this.project1.getMembers()
+            , members2 = this.project2.getMembers();
+
+          await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[0],
+            this.users[1],
+            this.users[2],
+            this.users[3],
+          ]);
+          await expect(members2, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[3],
+            this.users[4],
+            this.users[5],
+            this.users[6]
+          ]);
+
+          expect(this.User.findAll, 'was called once');
+          expect(this.User.findAll, 'to have a call satisfying', [{
+            include: [{
+              association: this.Project.Users.manyFromTarget,
+              where: { projectId: [ this.project1.get('id'), this.project2.get('id') ] }
+            }]
+          }]);
+        });
+
+        it('batches to multiple findAll call when different limits are applied', async function () {
+          let members1 = this.project1.getMembers({ limit: 4 })
+            , members2 = this.project2.getMembers({ limit: 2 })
+            , members3 = this.project3.getMembers({ limit: 2 });
+
+          await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[0],
+            this.users[1],
+            this.users[2],
+            this.users[3]
+          ]);
+          await expect(members2, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[3],
+            this.users[4]
+          ]);
+          await expect(members3, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[6],
+            this.users[7]
+          ]);
+
+          expect(this.User.findAll, 'was called twice');
+        });
+
+        it('batches to multiple findAll call with where + limit', async function () {
+          let members1 = this.project1.getMembers({ where: { awesome: true }, limit: 1 })
+            , members2 = this.project2.getMembers({ where: { awesome: true }, limit: 1 })
+            , members3 = this.project2.getMembers({ where: { awesome: false }, limit: 2 })
+            , members4 = this.project3.getMembers({ where: { awesome: true }, limit: 2 });
+
+          await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[1]
+          ]);
+          await expect(members2, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[4]
+          ]);
+          await expect(members3, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[3],
+            this.users[5]
+          ]);
+          await expect(members4, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[6],
+            this.users[7]
+          ]);
+
+          expect(this.User.findAll, 'was called thrice');
+          expect(this.User.findAll, 'to have a call satisfying', [{
+            where: {
+              awesome: true
+            },
+            groupedLimit: {
+              on: this.Project.Users.paired,
+              limit: 1,
+              values: [this.project1.get('id'), this.project2.get('id')]
+            }
+          }]);
+          expect(this.User.findAll, 'to have a call satisfying', [{
+            where: {
+              awesome: true
+            },
+            groupedLimit: {
+              on: this.Project.Users.paired,
+              limit: 2,
+              values: [this.project3.get('id')]
+            }
+          }]);
+          expect(this.User.findAll, 'to have a call satisfying', [{
+            where: {
+              awesome: false
+            },
+            groupedLimit: {
+              on: this.Project.Users.paired,
+              limit: 2,
+              values: [this.project2.get('id')]
+            }
+          }]);
+        });
       });
-      this.Project = connection.define('project');
-
-      this.Project.Users = this.Project.belongsToMany(this.User, { as: 'members', through: 'project_members' });
-      this.User.belongsToMany(this.Project, { through: 'project_members' });
-
-      await connection.sync({
-        force: true
-      });
-
-      [this.project1, this.project2, this.project3] = await this.Project.bulkCreate([
-        { id: randint() },
-        { id: randint() },
-        { id: randint() }
-      ], {returning: true});
-      this.users = await this.User.bulkCreate([
-        { id: randint(), awesome: false},
-        { id: randint(), awesome: true },
-        { id: randint(), awesome: true },
-        { id: randint(), awesome: false },
-        { id: randint(), awesome: true },
-        { id: randint(), awesome: false },
-        { id: randint(), awesome: true },
-        { id: randint(), awesome: true },
-        { id: randint(), awesome: true }
-      ], {returning: true});
-
-      await this.project1.setMembers(this.users.slice(0, 4));
-      await this.project2.setMembers(this.users.slice(3, 7));
-      await this.project3.setMembers(this.users.slice(6));
-
-      dataloaderSequelize(this.Project);
-      this.sandbox.spy(this.User, 'findAll');
-    });
-
-    it('batches to a single findAll call', async function () {
-      let members1 = this.project1.getMembers()
-        , members2 = this.project2.getMembers();
-
-      await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[0],
-        this.users[1],
-        this.users[2],
-        this.users[3],
-      ]);
-      await expect(members2, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[3],
-        this.users[4],
-        this.users[5],
-        this.users[6]
-      ]);
-
-      expect(this.User.findAll, 'was called once');
-      expect(this.User.findAll, 'to have a call satisfying', [{
-        include: [{
-          association: this.Project.Users.manyFromTarget,
-          where: { projectId: [ this.project1.get('id'), this.project2.get('id') ] }
-        }]
-      }]);
-    });
-
-    it('batches to multiple findAll call when different limits are applied', async function () {
-      let members1 = this.project1.getMembers({ limit: 4 })
-        , members2 = this.project2.getMembers({ limit: 2 })
-        , members3 = this.project3.getMembers({ limit: 2 });
-
-      await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[0],
-        this.users[1],
-        this.users[2],
-        this.users[3]
-      ]);
-      await expect(members2, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[3],
-        this.users[4]
-      ]);
-      await expect(members3, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[6],
-        this.users[7]
-      ]);
-
-      expect(this.User.findAll, 'was called twice');
-    });
-
-    it('batches to multiple findAll call with where + limit', async function () {
-      let members1 = this.project1.getMembers({ where: { awesome: true }, limit: 1 })
-        , members2 = this.project2.getMembers({ where: { awesome: true }, limit: 1 })
-        , members3 = this.project2.getMembers({ where: { awesome: false }, limit: 2 })
-        , members4 = this.project3.getMembers({ where: { awesome: true }, limit: 2 });
-
-      await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[1]
-      ]);
-      await expect(members2, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[4]
-      ]);
-      await expect(members3, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[3],
-        this.users[5]
-      ]);
-      await expect(members4, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
-        this.users[6],
-        this.users[7]
-      ]);
-
-      expect(this.User.findAll, 'was called thrice');
-      expect(this.User.findAll, 'to have a call satisfying', [{
-        where: {
-          awesome: true
-        },
-        groupedLimit: {
-          on: this.Project.Users.paired,
-          limit: 1,
-          values: [this.project1.get('id'), this.project2.get('id')]
-        }
-      }]);
-      expect(this.User.findAll, 'to have a call satisfying', [{
-        where: {
-          awesome: true
-        },
-        groupedLimit: {
-          on: this.Project.Users.paired,
-          limit: 2,
-          values: [this.project3.get('id')]
-        }
-      }]);
-      expect(this.User.findAll, 'to have a call satisfying', [{
-        where: {
-          awesome: false
-        },
-        groupedLimit: {
-          on: this.Project.Users.paired,
-          limit: 2,
-          values: [this.project2.get('id')]
-        }
-      }]);
     });
   });
 });

--- a/test/integration/findById.test.js
+++ b/test/integration/findById.test.js
@@ -30,6 +30,11 @@ describe('findById', function () {
       ], { returning: true });
     });
 
+    it('works with null', async function () {
+      await expect(this.User.findById(null), 'to be fulfilled with', null);
+      expect(this.User.findAll, 'was not called');
+    });
+
     it('batches to a single findAll call', async function () {
       let user1 = this.User.findById(this.users[2].get('id'))
         , user2 = this.User.findById(this.users[1].get('id'));

--- a/test/unit/shimming.test.js
+++ b/test/unit/shimming.test.js
@@ -3,6 +3,7 @@ import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 import sinon from 'sinon';
 import Promise from 'bluebird';
+import shimmer from 'shimmer';
 
 describe('shimming', function () {
   beforeEach(function () {
@@ -43,6 +44,13 @@ describe('shimming', function () {
       expect(this.User.Tasks.get, 'to be shimmed');
       expect(this.User.PrimaryTask.get, 'to be shimmed');
       expect(this.Task.User.get, 'to be shimmed');
+    });
+
+    it('shims only once', function () {
+      this.sandbox.stub(shimmer, 'wrap');
+      dataloaderSequelize(connection);
+
+      expect(shimmer.wrap, 'was not called');
     });
   });
 

--- a/test/unit/shimming.test.js
+++ b/test/unit/shimming.test.js
@@ -1,9 +1,12 @@
 import {connection} from '../helper';
 import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
+import sinon from 'sinon';
+import Promise from 'bluebird';
 
 describe('shimming', function () {
   beforeEach(function () {
+    this.sandbox = sinon.sandbox.create();
     this.User = connection.define('user');
     this.Task = connection.define('task');
 
@@ -12,20 +15,23 @@ describe('shimming', function () {
     this.Task.User = this.Task.belongsTo(this.User);
   });
 
+  afterEach(function () {
+    [
+      connection.Model.prototype.findByPrimary,
+      connection.Model.prototype.findById,
+      connection.Association.BelongsTo.prototype.get,
+      connection.Association.HasOne.prototype.get,
+      connection.Association.HasMany.prototype.get,
+      connection.Association.BelongsToMany.prototype.get
+    ].forEach(i => i.__unwrap && i.__unwrap());
+
+    this.sandbox.restore();
+    connection.modelManager.forEachModel(connection.modelManager.removeModel.bind(connection.modelManager));
+  });
+
   describe('sequelize constructor', function () {
     beforeEach(function () {
       dataloaderSequelize(connection);
-    });
-
-    afterEach(function () {
-      [
-        connection.Model.prototype.findByPrimary,
-        connection.Model.prototype.findById,
-        connection.Association.BelongsTo.prototype.get,
-        connection.Association.HasOne.prototype.get,
-        connection.Association.HasMany.prototype.get,
-        connection.Association.BelongsToMany.prototype.get
-      ].forEach(i => i.__unwrap());
     });
 
     it('shims all models', function () {
@@ -71,9 +77,7 @@ describe('shimming', function () {
     });
 
     afterEach(function () {
-      [
-        this.User.Tasks.get
-      ].forEach(i => i.__unwrap());
+      this.User.Tasks.get.__unwrap();
     });
 
     it('does not shim models', function () {
@@ -88,11 +92,25 @@ describe('shimming', function () {
     });
   });
 
-  it('throws error for non-paired BTM', function () {
-    let UserTasks = this.User.belongsToMany(this.Task, { through: 'foobar' });
-    dataloaderSequelize(UserTasks);
+  describe('paired BTM', function () {
+    it('does not throw an error when attached to the prototype', async function () {
+      this.sandbox.stub(this.Task, 'findAll').resolves();
+      dataloaderSequelize(connection);
 
-    expect(() => UserTasks.get(), 'to throw');
+      let UserTasks = this.User.belongsToMany(this.Task, { through: 'foobar' });
+      this.Task.belongsToMany(this.User, { through: 'foobar' });
+
+      expect(() => UserTasks.get(this.User.build({ id: 42 })), 'not to throw');
+      await Promise.delay(1);
+      expect(this.Task.findAll, 'was called once');
+    });
+
+    it('throws error for non-paired BTM', function () {
+      let UserTasks = this.User.belongsToMany(this.Task, { through: 'foobar' });
+      dataloaderSequelize(UserTasks);
+
+      expect(() => UserTasks.get(this.User.build({ id: 42 })), 'to throw');
+    });
   });
 });
 


### PR DESCRIPTION
This fixes some small bugs I found during my benchmarks.

1. Belongs to many worked with string through, but not model. The check for `paired` was wrong (we checked on the prototype, not the instance). We were too quick to remove `options.association`, so it wasn't available the second time the loader runs
2. Handling on `findById(null)` - otherwise dataloader complains about trying to load a null key
3. We check before trying to shim again. This means we can call `dataloaderSequelize(model)` in the graphql-sequelize resolver and not worry about shimming more than once