### PR TITLE
fix: Use duck-typing to detect target type during injection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function mapResult(attribute, keys, options, result) {
 }
 
 function stringifyValue(value, key) {
-  if (value instanceof Sequelize.Association) {
+  if (value.associationType) {
     return `${value.associationType},${value.target.name},${value.as}`;
   } else if (Array.isArray(value)) {
     if (key !== 'order') {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function mapResult(attribute, keys, options, result) {
 }
 
 function stringifyValue(value, key) {
-  if (value.associationType) {
+  if (value && value.associationType) {
     return `${value.associationType},${value.target.name},${value.as}`;
   } else if (Array.isArray(value)) {
     if (key !== 'order') {


### PR DESCRIPTION
A bit of context for people who are not Mick and me :)

There are some cases where you might end up with two different instances of sequelize installed - instanceof checks between the two instances won't work.

This can happen if you have to dependencies which require sequelize, but your parent project does not. In our case, all models and sequelize setup is wrapped in `db` package, which requires sequelize. `dataloader-sequelize` lists sequelize as a peer dependency, but npm v2 is not smart enough to figure out that it could simply install sequelize higher up. This leads to the following dependency tree.

```bash
$ npm ls sequelize
@snaplytics/graphql@1.104.0 /home/jan/src/snap/graphql
├─┬ @snaplytics/db@2.55.0
│ └── sequelize@3.24.4 
└─┬ graphql-sequelize@4.0.0
  └── sequelize@3.24.4 
```

In our case this meant that dataloader-sequelize is simply not attached to anything, since all instanceof checks fail.