### PR TITLE
fix belongsToMany limit issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,16 +112,15 @@ function loaderForBTM(model, joinTableName, foreignKey, foreignKeyField, options
           limit: findOptions.limit,
           values: keys
         };
-      } else {
-        findOptions.include = [{
-          attributes: [foreignKey],
-          association: association.manyFromSource,
-          where: {
-            [foreignKeyField]: keys,
-            ...options.through.where
-          }
-        }];
       }
+      findOptions.include = [{
+        attributes: [foreignKey],
+        association: association.manyFromSource,
+        where: {
+          [foreignKeyField]: keys,
+          ...options.through.where
+        }
+      }];
 
       return model.findAll(findOptions).then(mapResult.bind(null, attributes, keys, findOptions));
     }, {


### PR DESCRIPTION
Fix https://github.com/mickhansen/graphql-sequelize/issues/395

I found the root of the issue, but don't fully understand it

https://github.com/mickhansen/dataloader-sequelize/blob/master/src/index.js#L108  has a special handling for limit, cause `query.options.include` is undefined at https://github.com/sequelize/sequelize/blob/master/lib/dialects/sqlite/query.js#L154 , so that I get this issue `TypeError: Cannot read property 'getTableName' of undefined` at https://github.com/sequelize/sequelize/blob/master/lib/dialects/sqlite/query.js#L169