### PR TITLE
Add line for using require with project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ the batching functionality from dataloader, caching is disabled.
 ```js
 import dataloaderSequelize from 'dataloader-sequelize';
 
+//Note: if using require use the following syntax
+//const dataloaderSequelize = require('dataloader-sequelize').default;
+
 // Sequelize instance - wrap all current and future models and associations
 dataloaderSequelize(sequelize)
 


### PR DESCRIPTION
As discussed with Jan last night.  I noticed a small thing we using the dataloader-sequelizer with out ES6 module loading (i.e. require).  I just add a quick commented note in the docs about how to use this with require