### PR TITLE
Ignore findById and findByPrimary if has include

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ function shimModel(target) {
       if ([null, undefined].indexOf(id) !== -1) {
         return Promise.resolve(null);
       }
-      if (options.transaction) {
+      if (options.transaction || options.include) {
         return original.apply(this, arguments);
       }
       return loaderForModel(this, this.primaryKeyAttribute, this.primaryKeyField).load(id).then(rejectOnEmpty.bind(null, options));

--- a/test/integration/hasMany.test.js
+++ b/test/integration/hasMany.test.js
@@ -265,6 +265,17 @@ describe('hasMany', function () {
         limit: 1
       }]);
     });
+
+    it('should do stuff', async function() {
+      let project1 = await this.Project.findById(this.project1.id, { include: [ this.Project.associations.members ]});
+      let project2 = await this.Project.findById(this.project2.id, { include: [ this.Project.associations.members ]});
+
+      expect(project1.members, 'not to be undefined');
+      expect(project2.members, 'not to be undefined');
+      expect(project1.members.length, 'to equal', 3);
+      expect(project2.members.length, 'to equal', 4);
+    });
+
   });
 
   describe('paranoid', function () {

--- a/test/integration/hasMany.test.js
+++ b/test/integration/hasMany.test.js
@@ -1,6 +1,7 @@
 import Sequelize from 'sequelize';
 import {connection, randint} from '../helper';
 import sinon from 'sinon';
+import DataLoader from 'dataloader';
 import dataloaderSequelize from '../../src';
 import expect from 'unexpected';
 
@@ -266,14 +267,17 @@ describe('hasMany', function () {
       }]);
     });
 
-    it('should do stuff', async function() {
+    it('should skip batching if include is set', async function() {
+      let DataLoaderSpy = this.sandbox.spy(DataLoader);
       let project1 = await this.Project.findById(this.project1.id, { include: [ this.Project.associations.members ]});
       let project2 = await this.Project.findById(this.project2.id, { include: [ this.Project.associations.members ]});
 
       expect(project1.members, 'not to be undefined');
       expect(project2.members, 'not to be undefined');
-      expect(project1.members.length, 'to equal', 3);
-      expect(project2.members.length, 'to equal', 4);
+      expect(project1.members, 'to have length', 3);
+      expect(project2.members, 'to have length', 4);
+
+      expect(DataLoaderSpy.calledWithNew(), 'to be false');
     });
 
   });

--- a/test/integration/hasMany.test.js
+++ b/test/integration/hasMany.test.js
@@ -268,7 +268,7 @@ describe('hasMany', function () {
     });
 
     it('should skip batching if include is set', async function() {
-      let DataLoaderSpy = this.sandbox.spy(DataLoader);
+      this.sandbox.spy(DataLoader.prototype, 'load');
       let project1 = await this.Project.findById(this.project1.id, { include: [ this.Project.associations.members ]});
       let project2 = await this.Project.findById(this.project2.id, { include: [ this.Project.associations.members ]});
 
@@ -276,8 +276,7 @@ describe('hasMany', function () {
       expect(project2.members, 'not to be undefined');
       expect(project1.members, 'to have length', 3);
       expect(project2.members, 'to have length', 4);
-
-      expect(DataLoaderSpy.calledWithNew(), 'to be false');
+      expect(DataLoader.prototype.load, 'was not called');
     });
 
   });


### PR DESCRIPTION
Will do normal `findById` if `include` option is set.
This fixes the issue of missing associations

Fixes #24 and https://github.com/mickhansen/graphql-sequelize/issues/358