### PR TITLE
Adds support for hasMany sourceKey

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,10 +251,12 @@ function shimHasMany(target) {
         ...options
       });
 
+      let key = this.sourceKey || this.source.primarKeyAttribute;
+
       if (Array.isArray(instances)) {
-        return Promise.map(instances, instance => loader.load(instance.get(this.sourceKey)));
+        return Promise.map(instances, instance => loader.load(instance.get(key)));
       } else {
-        return loader.load(instances.get(this.sourceKey)).then(result => {
+        return loader.load(instances.get(key)).then(result => {
           if (isCount && !result) {
             result = { count: 0 };
           }

--- a/src/index.js
+++ b/src/index.js
@@ -251,7 +251,7 @@ function shimHasMany(target) {
         ...options
       });
 
-      let key = this.sourceKey || this.source.primarKeyAttribute;
+      let key = this.sourceKey || this.source.primaryKeyAttribute;
 
       if (Array.isArray(instances)) {
         return Promise.map(instances, instance => loader.load(instance.get(key)));

--- a/src/index.js
+++ b/src/index.js
@@ -252,9 +252,9 @@ function shimHasMany(target) {
       });
 
       if (Array.isArray(instances)) {
-        return Promise.map(instances, instance => loader.load(instance.get(this.source.primaryKeyAttribute)));
+        return Promise.map(instances, instance => loader.load(instance.get(this.sourceKey)));
       } else {
-        return loader.load(instances.get(this.source.primaryKeyAttribute)).then(result => {
+        return loader.load(instances.get(this.sourceKey)).then(result => {
           if (isCount && !result) {
             result = { count: 0 };
           }


### PR DESCRIPTION
This commit adds support for hasMany sourceKey which was introduced in sequelize 3.30.0

I can add additional tests if required.