### PR TITLE
Also include model schema name in cache key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,8 +66,12 @@ function stringifyObject(object, keys = Object.keys(object)) {
 export function getCacheKey(model, attribute, options) {
   options = stringifyObject(options, ['association', 'attributes', 'groupedLimit', 'limit', 'offset', 'order', 'where', 'through', 'raw']);
 
-  const schema = model.options.schema || '';
-  return `${schema}|${model.name}|${attribute}|${options}`;
+  let name = `${model.name}|${attribute}|${options}`;
+  const schema = model.options && model.options.schema;
+  if (schema) {
+    name = `${schema}|${name}`;
+  }
+  return name;
 }
 
 function mergeWhere(where, optionsWhere) {

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,8 @@ function stringifyObject(object, keys = Object.keys(object)) {
 export function getCacheKey(model, attribute, options) {
   options = stringifyObject(options, ['association', 'attributes', 'groupedLimit', 'limit', 'offset', 'order', 'where', 'through', 'raw']);
 
-  return `${model.name}|${attribute}|${options}`;
+  const schema = model.options.schema || '';
+  return `${schema}|${model.name}|${attribute}|${options}`;
 }
 
 function mergeWhere(where, optionsWhere) {

--- a/test/unit/getCacheKey.test.js
+++ b/test/unit/getCacheKey.test.js
@@ -53,6 +53,17 @@ describe('getCacheKey', function () {
     }), 'to equal', 'user|id|association:undefined|attributes:bar,baz,foo|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:undefined');
   });
 
+  it('handles schemas', function () {
+    expect(getCacheKey({
+      name: 'user',
+      options: {
+        schema: 'app'
+      }
+    }, 'id', {
+      attributes: ['foo', 'bar', 'baz']
+    }), 'to equal', 'app|user|id|association:undefined|attributes:bar,baz,foo|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:undefined');
+  });
+
   describe('where statements', function () {
     it('POJO', function () {
       expect(getCacheKey(User, 'id', {


### PR DESCRIPTION
I have come across a project that has same model names in different schemas. Currently, `dataloader-sequelize` does not consider the schema name when deriving the cache key, which results in loaders for different models clobbering each other.