### PR TITLE
A class extending `Sequelize.Model` should be resolved.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,7 +362,7 @@ export default function (target, options = {}) {
 
   if (target.associationType) {
     shimAssociation(target);
-  } else if (/(SequelizeModel|class extends Model)/.test(target.toString())) {
+  } else if (/(SequelizeModel|class extends Model)/.test(target.toString()) || Sequelize.Model.isPrototypeOf(target)) {
     shimModel(target);
     values(target.associations).forEach(shimAssociation);
   } else {


### PR DESCRIPTION
How to reproduce:

```javascript
const {resolver} = require('graphql-sequelize');

const Sequelize = require('sequelize');
const SequelizeModel = Sequelize.Model;
const sequelize = new Sequelize('sqlite://')

const MyModel = sequelize.define('MyModel');

resolver(MyModel);

class MyAnotherModel extends Sequelize.Model {}
MyAnotherModel.init({}, {sequelize});

// Will throw a TypeError
resolver(MyAnotherModel);
```
```
TypeError: Cannot read property 'findById' of undefined
    at shimModel (C:\Users\Donghwan\git\api-research\node_modules\dataloader-sequelize\lib\index.js:245:13)
    at exports.default (C:\Users\Donghwan\git\api-research\node_modules\dataloader-sequelize\lib\index.js:34:5)
    at resolverFactory (C:\Users\Donghwan\git\api-research\node_modules\graphql-sequelize\lib\resolver.js:42:37)
    at repl:1:1
    at sigintHandlersWrap (vm.js:22:35)
    at sigintHandlersWrap (vm.js:96:12)
    at ContextifyScript.Script.runInThisContext (vm.js:21:12)
    at REPLServer.defaultEval (repl.js:313:29)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:513:10)
    at emitOne (events.js:101:20)
    at REPLServer.emit (events.js:188:7)
    at REPLServer.Interface._onLine (readline.js:239:10)
    at REPLServer.Interface._line (readline.js:585:8)
    at REPLServer.Interface._ttyWrite (readline.js:862:14)
    at REPLServer.self._ttyWrite (repl.js:605:7)
    at ReadStream.onkeypress (readline.js:126:10)
    at emitTwo (events.js:106:13)
    at ReadStream.emit (events.js:191:7)
    at emitKeys (internal/readline.js:389:14)
    at next (native)
```

I've dug further and found this line occurs the issue - https://github.com/mickhansen/dataloader-sequelize/blob/d1aac7660b4c93ffc8a265d4d30ec914a42ae54c/src/index.js#L365

I don't understand why toString method is used. `const SequelizeModel = Sequelize.Model` and `class MyYetAnotherModel extends SequelizeModel` can work around but `isPrototypeOf` can fix the fundamental issue.

Here's simple unit test w/ the patch:

```javascript
const {resolver} = require('graphql-sequelize');

const Sequelize = require('sequelize');
const SequelizeModel = Sequelize.Model;
const sequelize = new Sequelize('sqlite://')

const MyModel = sequelize.define('MyModel');

assert.doesNotThrow(() => resolver(MyModel), TypeError);

class MyAnotherModel extends Sequelize.Model {}
MyAnotherModel.init({}, {sequelize});

assert.doesNotThrow(() => resolver(MyAnotherModel), TypeError);
```

I didn't add tests because I wasn't sure where I should put it to. If you think it's required, please tell me.