### PR TITLE
pass options into loaderForModel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -184,7 +184,7 @@ function shimModel(target) {
       if (options.transaction || options.include) {
         return original.apply(this, arguments);
       }
-      return loaderForModel(this, this.primaryKeyAttribute, this.primaryKeyField).load(id).then(rejectOnEmpty.bind(null, options));
+      return loaderForModel(this, this.primaryKeyAttribute, this.primaryKeyField, options).load(id).then(rejectOnEmpty.bind(null, options));
     };
   });
 }


### PR DESCRIPTION
when we use findById with paranoid option,  the paranoid wasn't passed into the loaderForModel function