### PR TITLE
fix TypeError in getCacheKey with multiple Symbols

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,13 @@ function stringifyValue(value, key) {
 // depends on the order in which the properties were defined - which we don't like!
 // Additionally, JSON.stringify escapes strings, which we don't need here
 function stringifyObject(object, keys = [...Object.keys(object), ...Object.getOwnPropertySymbols(object)]) {
-  return keys.sort().map(key => `${key.toString()}:${stringifyValue(object[key], key)}`).join('|');
+  return keys.sort((lhs, rhs) => {
+    const l = lhs.toString();
+    const r = rhs.toString();
+    if (l > r) return 1;
+    if (l < r) return -1;
+    return 0;
+  }).map(key => `${key.toString()}:${stringifyValue(object[key], key)}`).join('|');
 }
 
 export function getCacheKey(model, attribute, options) {

--- a/test/unit/getCacheKey.test.js
+++ b/test/unit/getCacheKey.test.js
@@ -79,10 +79,13 @@ describe('getCacheKey', function () {
         where: {
           [Symbol('or')]: {
             name: { [Symbol('iLike')]: '%test%' }
+          },
+          [Symbol('or')]: {
+            name: { [Symbol('iLike')]: '%test%' }
           }
         }
       }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:Symbol(or):name:Symbol(iLike):%test%');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:Symbol(or):name:Symbol(iLike):%test%|Symbol(or):name:Symbol(iLike):%test%');
     });
 
     it('date', function () {


### PR DESCRIPTION
This fixes the following bug.

`TypeError` occurred in getCacheKey with multiple symbols.
e.g. ) 
```javascript
getCacheKey(Model, 'attr', {
  where: {
    [Symbol('or')]: { ... },
    [Symbol('or')]: { ... },
  },
}); // => TypeError: Cannot convert a Symbol value to a string
```