### PR TITLE
Add CLS awareness

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ dataloader-sequelize is designed to provide per-request catching/batching for se
 * Should be called after all models and associations are defined
 * `sequelize` a sequelize instance
 * `options.max=500` the maximum number of simultaneous dataloaders to store in memory. The loaders are stored in an LRU cache
-* `options.clsNamespace` The CLS namespace used by Sequelize to manage transactions
 
 # Usage
 ```js

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ dataloader-sequelize is designed to provide per-request catching/batching for se
 * Should be called after all models and associations are defined
 * `sequelize` a sequelize instance
 * `options.max=500` the maximum number of simultaneous dataloaders to store in memory. The loaders are stored in an LRU cache
+* `options.clsNamespace` The CLS namespace used by Sequelize to manage transactions
 
 # Usage
 ```js

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.9.0",
     "bluebird": "^3.4.6",
+    "continuation-local-storage": "^3.2.1",
     "eslint": "^3.0.0",
     "isparta": "^4.0.0",
     "mocha": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -427,9 +427,12 @@ export function resetCache() {
   if (GLOBAL_CACHE) GLOBAL_CACHE.reset();
 }
 
-let clsNamespace;
 function activeClsTransaction() {
-  if (clsNamespace && clsNamespace.get('transaction')) {
+  if (/^4/.test(Sequelize.version)) {
+    if (Sequelize._cls && Sequelize._cls.get('transaction')) {
+      return true;
+    }
+  } else if (Sequelize.cls && Sequelize.cls.get('transaction')) {
     return true;
   }
   return false;
@@ -443,10 +446,6 @@ export default function (target, options = {}) {
 
   if (!GLOBAL_CACHE) {
     GLOBAL_CACHE = LRU(options);
-  }
-
-  if (options.clsNamespace) {
-    clsNamespace = options.clsNamespace;
   }
 
   if (target.associationType) {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -30,9 +30,7 @@ describe('Transactions', function () {
         { id: randint() },
         { id: randint() }
       ], { returning: true });
-      
 
-      this.sandbox.spy(this.User, 'findById');
       this.sandbox.spy(this.User, 'findAll');
     });
 
@@ -65,7 +63,7 @@ describe('Transactions', function () {
       
       this.User = connection.define('user');
     
-      dataloaderSequelize(this.User, { clsNamespace: this.namespace });
+      dataloaderSequelize(this.User);
 
       await connection.sync({
         force: true
@@ -75,9 +73,7 @@ describe('Transactions', function () {
         { id: randint() },
         { id: randint() }
       ], { returning: true });
-      
 
-      this.sandbox.spy(this.User, 'findById');
       this.sandbox.spy(this.User, 'findAll');
     })
 

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -1,0 +1,108 @@
+import {connection, randint} from '../helper';
+import Sequelize from 'sequelize';
+import sinon from 'sinon';
+import dataloaderSequelize from '../../src';
+import expect from 'unexpected';
+import Promise from 'bluebird';
+import cls from 'continuation-local-storage';
+
+describe('Transactions', function () {
+  beforeEach(async function () {
+    this.sandbox = sinon.sandbox.create();
+  });
+  afterEach(function () {
+    this.sandbox.restore();
+  });
+
+  describe('Managed', function () {
+    beforeEach(async function () {
+      this.sandbox = sinon.sandbox.create();
+
+      this.User = connection.define('user');
+    
+      dataloaderSequelize(this.User);
+
+      await connection.sync({
+        force: true
+      });
+
+      this.users = await this.User.bulkCreate([
+        { id: randint() },
+        { id: randint() }
+      ], { returning: true });
+      
+
+      this.sandbox.spy(this.User, 'findById');
+      this.sandbox.spy(this.User, 'findAll');
+    });
+
+    it('does not batch during managed transactions', async function () {
+      let user1, user2;
+      await connection.transaction(async (t) => {
+        [user1, user2] = await Promise.all([this.User.findById(this.users[1].get('id'), {transaction: t}),
+          this.User.findById(this.users[0].get('id'), {transaction: t})]);
+      });
+      expect(user1, 'to equal', this.users[1]);
+      expect(user2, 'to equal', this.users[0]);
+
+      expect(this.User.findAll, 'not to have calls satisfying', [{
+        where: {
+          id: [this.users[1].get('id'), this.users[0].get('id')]
+        }
+      }]);
+    });
+  });
+
+  describe('CLS', function () {
+    beforeEach(async function () {
+      this.namespace = cls.createNamespace('sequelize');
+      if (/^4/.test(Sequelize.version)) {
+        Sequelize.useCLS(this.namespace);
+      } else {
+        Sequelize.cls = this.namespace;
+      }
+      this.sandbox = sinon.sandbox.create();
+      
+      this.User = connection.define('user');
+    
+      dataloaderSequelize(this.User, { clsNamespace: this.namespace });
+
+      await connection.sync({
+        force: true
+      });
+
+      this.users = await this.User.bulkCreate([
+        { id: randint() },
+        { id: randint() }
+      ], { returning: true });
+      
+
+      this.sandbox.spy(this.User, 'findById');
+      this.sandbox.spy(this.User, 'findAll');
+    })
+
+    after(function () {
+      if (/^4/.test(Sequelize.version)) {
+        delete Sequelize._cls;
+      } else {
+        delete Sequelize.cls;
+      }
+    })
+
+    it('does not batch during CLS transactions', async function () {
+      let user1, user2;
+      await connection.transaction(async (t) => {
+        [user1, user2] = await Promise.all([this.User.findById(this.users[1].get('id')),
+          this.User.findById(this.users[0].get('id'))]);
+      });
+      expect(user1, 'to equal', this.users[1]);
+      expect(user2, 'to equal', this.users[0]);
+
+      expect(this.User.findAll, 'not to have calls satisfying', [{
+        where: {
+          id: [this.users[1].get('id'), this.users[0].get('id')]
+        }
+      }]);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds the possibility to make the dataloader aware of transactions when using CLS. When there is a transaction, the queries are no longer batched. This makes the behavior consistent when using either managed or cls transactions.  
The CLS namespace has to be passed as an options parameter when initializing the dataloader.