### PR TITLE
convert $and operator alias to [Sequelize.Op.and]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ export function getCacheKey(model, attribute, options) {
 function mergeWhere(where, optionsWhere) {
   if (optionsWhere) {
     return {
-      [Sequelize.Op.and]: [where, optionsWhere]
+      [Sequelize.Op ? Sequelize.Op.and : '$and']: [where, optionsWhere]
     };
   }
   return where;

--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ export function getCacheKey(model, attribute, options) {
 function mergeWhere(where, optionsWhere) {
   if (optionsWhere) {
     return {
-      $and: [where, optionsWhere]
+      [Sequelize.Op.and]: [where, optionsWhere]
     };
   }
   return where;


### PR DESCRIPTION
Operators alias are already deprecated in Sequelize 4 and it's already advised to run without it.

In Sequelize 5 they will be completely gone.

This change removes the $and operator and uses the future-proof syntax.