### PR TITLE
Convert missing $and operator alias to [Sequelize.Op.and]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ function shimHasMany(target) {
 
       if (this.scope) {
         options.where = {
-          $and: [
+          [Sequelize.Op ? Sequelize.Op.and : '$and']: [
             options.where,
             this.scope
           ]
@@ -361,7 +361,7 @@ function shimBelongsToMany(target) {
 
       if (this.scope) {
         options.where = {
-          $and: [
+          [Sequelize.Op ? Sequelize.Op.and : '$and']: [
             options.where,
             this.scope
           ]
@@ -371,7 +371,7 @@ function shimBelongsToMany(target) {
       options.through = options.through || {};
       if (this.through.scope) {
         options.through.where = {
-          $and: [
+          [Sequelize.Op ? Sequelize.Op.and : '$and']: [
             options.through.where,
             this.through.scope
           ]


### PR DESCRIPTION
We merged yesterday https://github.com/mickhansen/dataloader-sequelize/pull/52

I only noticed this morning that there were actually more occurrences of it.

Should we perhaps extract `[Sequelize.Op ? Sequelize.Op.and : '$and']` at the beginning of the file to avoid repeating ourselves?

Like `$and = [Sequelize.Op ? Sequelize.Op.and : '$and'];` And then only use `[$and]`;