### PR TITLE
Added paranoid option to the cache key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ function stringifyObject(object, keys = [...Object.keys(object), ...Object.getOw
 }
 
 export function getCacheKey(model, attribute, options) {
-  options = stringifyObject(options, ['association', 'attributes', 'groupedLimit', 'limit', 'offset', 'order', 'where', 'through', 'raw', 'searchPath']);
+  options = stringifyObject(options, ['association', 'attributes', 'groupedLimit', 'limit', 'offset', 'order', 'where', 'through', 'raw', 'searchPath', 'paranoid']);
 
   let name = `${model.name}|${attribute}|${options}`;
   const schema = model.options && model.options.schema;


### PR DESCRIPTION
Hello,

I added the paranoid option to the cache key so consecutive calls with different paranoid settings can show the correct results : 

```javascript
User.findAll({paranoid: false});
User.findAll({paranoid: true});
```