### PR TITLE
Add tests for paranoid cache key

### DIFF
--- a/test/unit/getCacheKey.test.js
+++ b/test/unit/getCacheKey.test.js
@@ -21,13 +21,13 @@ describe('getCacheKey', function () {
     expect(getCacheKey({
       name: 'user'
     }, 'id', options), 'to equal',
-      'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
+      'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
   });
 
   it('handles nulls', function () {
     expect(getCacheKey(User, 'id', {
       order: null
-    }), 'to equal', 'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:null|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
+    }), 'to equal', 'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:null|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
   });
 
   it('does not modify arrays', function () {
@@ -36,7 +36,7 @@ describe('getCacheKey', function () {
     };
 
     expect(getCacheKey(User, 'id', options), 'to equal',
-      'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:foo,bar|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
+      'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:foo,bar|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
     expect(options.order, 'to equal', ['foo', 'bar']);
   });
 
@@ -44,13 +44,13 @@ describe('getCacheKey', function () {
     expect(getCacheKey(User, 'id', {
       association,
       limit: 42
-    }), 'to equal', 'user|id|association:HasMany,task,tasks|attributes:undefined|groupedLimit:undefined|limit:42|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
+    }), 'to equal', 'user|id|association:HasMany,task,tasks|attributes:undefined|groupedLimit:undefined|limit:42|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
   });
 
   it('handles attributes', function () {
     expect(getCacheKey(User, 'id', {
       attributes: ['foo', 'bar', 'baz']
-    }), 'to equal', 'user|id|association:undefined|attributes:bar,baz,foo|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
+    }), 'to equal', 'user|id|association:undefined|attributes:bar,baz,foo|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
   });
 
   it('handles schemas', function () {
@@ -61,7 +61,7 @@ describe('getCacheKey', function () {
       }
     }, 'id', {
       attributes: ['foo', 'bar', 'baz']
-    }), 'to equal', 'app|user|id|association:undefined|attributes:bar,baz,foo|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
+    }), 'to equal', 'app|user|id|association:undefined|attributes:bar,baz,foo|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:undefined');
   });
 
   describe('where statements', function () {
@@ -71,7 +71,7 @@ describe('getCacheKey', function () {
           completed: true
         }
       }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:completed:true');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:completed:true');
     });
 
     it('symbols', function () {
@@ -85,7 +85,7 @@ describe('getCacheKey', function () {
           }
         }
       }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:Symbol(or):name:Symbol(iLike):%test%|Symbol(or):name:Symbol(iLike):%test%');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:Symbol(or):name:Symbol(iLike):%test%|Symbol(or):name:Symbol(iLike):%test%');
     });
 
     it('date', function () {
@@ -102,7 +102,7 @@ describe('getCacheKey', function () {
           }
         }
       }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:completed:$between:2016-02-01T00:00:00.000Z,2016-03-01T00:00:00.000Z');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:completed:$between:2016-02-01T00:00:00.000Z,2016-03-01T00:00:00.000Z');
     });
 
     it('literal', function () {
@@ -111,7 +111,7 @@ describe('getCacheKey', function () {
           foo: connection.literal('SELECT foo FROM bar')
         }
       }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:foo:val:SELECT foo FROM bar');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:foo:val:SELECT foo FROM bar');
     });
 
     it('fn + col', function () {
@@ -122,7 +122,7 @@ describe('getCacheKey', function () {
           }
         }
       }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:undefined|through:undefined|where:foo:$gt:args:col:bar|fn:FOO');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:undefined|through:undefined|where:foo:$gt:args:col:bar|fn:FOO');
     });
   });
 
@@ -130,7 +130,7 @@ describe('getCacheKey', function () {
     expect(getCacheKey(User, 'id', {
       searchPath: 'test'
     }), 'to equal',
-        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|searchPath:test|through:undefined|where:undefined');
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|paranoid:undefined|raw:undefined|searchPath:test|through:undefined|where:undefined');
   });
 
 });


### PR DESCRIPTION
Was looking at a fix for grouped where-limits and found the original tests were failing due to the new paranoid option: 

![screenshot 2018-11-05 16 23 55](https://user-images.githubusercontent.com/1162531/48007111-384f0400-e117-11e8-93c1-056507d89f3e.png)
