### PR TITLE
Fix duplicate WHERE x LIMIT y clauses getting unioned

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import Sequelize from 'sequelize';
 import shimmer from 'shimmer';
 import DataLoader from 'dataloader';
 import Promise from 'bluebird';
-import {groupBy, property, values, clone, isEmpty} from 'lodash';
+import {groupBy, property, values, clone, isEmpty, uniq} from 'lodash';
 import LRU from 'lru-cache';
 import assert from 'assert';
 
@@ -137,7 +137,7 @@ function loaderForBTM(model, joinTableName, foreignKey, foreignKeyField, options
         through: options.through,
         on: association,
         limit: findOptions.limit,
-        values: keys
+        values: uniq(keys)
       };
     } else {
       findOptions.include = [{
@@ -182,7 +182,7 @@ function loaderForModel(model, attribute, attributeField, options = {}) {
       findOptions.groupedLimit = {
         limit: findOptions.limit,
         on: attributeField,
-        values: keys
+        values: uniq(keys)
       };
       delete findOptions.limit;
     } else {

--- a/test/integration/belongsToMany.test.js
+++ b/test/integration/belongsToMany.test.js
@@ -274,7 +274,8 @@ describe('belongsToMany', function () {
           let members1 = this.project1.getMembers({ where: { awesome: true }, limit: 1 })
             , members2 = this.project2.getMembers({ where: { awesome: true }, limit: 1 })
             , members3 = this.project2.getMembers({ where: { awesome: false }, limit: 2 })
-            , members4 = this.project3.getMembers({ where: { awesome: true }, limit: 2 });
+            , members4 = this.project3.getMembers({ where: { awesome: true }, limit: 2 })
+            , members5 = this.project3.getMembers({ where: { awesome: true }, limit: 2 });
 
           await expect(members1, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
             this.users[1]
@@ -287,6 +288,10 @@ describe('belongsToMany', function () {
             this.users[5]
           ]);
           await expect(members4, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
+            this.users[6],
+            this.users[7]
+          ]);
+          await expect(members5, 'when fulfilled', 'with set semantics to exhaustively satisfy', [
             this.users[6],
             this.users[7]
           ]);


### PR DESCRIPTION
Fix #44 
Relates to: https://github.com/mickhansen/graphql-sequelize/issues/541

**current:**
unit: 21 passing (238ms)
integration:   59 passing (6s) 2 failing

**new:**
unit: 21 passing (238ms)
integration: 61 passing (6s)

Also tested this change locally on my own problem and can confirm that it fixes it.

Before has duplicate rows:
![screenshot 2018-11-05 17 53 19](https://user-images.githubusercontent.com/1162531/48013036-b1545880-e123-11e8-8d25-6f091a6f4432.png)

After is correct:
![screenshot 2018-11-05 17 52 40](https://user-images.githubusercontent.com/1162531/48013024-a699c380-e123-11e8-8b32-d127acf6ff34.png)
