### PR TITLE
Support Sequelize v5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "isparta": "^4.0.0",
     "mocha": "^3.0.0",
     "pg": "^6.1.0",
-    "sequelize": "^5.0.0-beta.16",
+    "sequelize": "^5.0.0",
     "sinon": "^1.17.4",
     "sinon-as-promised": "^4.0.0",
     "unexpected": "^10.14.2",
@@ -42,7 +42,7 @@
     "unexpected-sinon": "^10.2.1"
   },
   "peerDependencies": {
-    "sequelize": "^3.24.6 || ^4.0.0"
+    "sequelize": "^3.24.6 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "dataloader": "^1.2.0",


### PR DESCRIPTION
With sequelize set to v5 as a regular dependency, I figured it was then acceptable to set it as such as a peerDependency. This should also fix the CI issue. Additionally, the v5 version is now out of beta and can be used as such.