### PR TITLE
Resolve promise when sourcekey is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,6 +248,10 @@ function shimHasOne(target) {
 
       return Promise.resolve().then(() => {
         const sourceKey = instance.get(this.sourceKey);
+        
+        if(!sourceKey) {
+          return Promise.resolve(null);
+        }
 
         const loaders = options[EXPECTED_OPTIONS_KEY].loaders;
         let loader = loaders[this.target.name].bySingleAttribute[this.foreignKey];


### PR DESCRIPTION
Been having issues when there is an empty relation on hasOne. The proposed change stops the loader being called when the foreign key is null. Which prevents the following error

`The loader.load() function must be called with a value,but got: null.`

This PR relates to the previously merged commit

https://github.com/mickhansen/dataloader-sequelize/pull/8/files